### PR TITLE
Add list

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -10,6 +10,7 @@ type List[T any] interface {
 	String() string
 	Clear()
 	Append(...T)
+	Clone() List[T]
 }
 
 // list[T] is an wrapper for the Go slices.
@@ -34,6 +35,15 @@ func (l *list[T]) Clear() { l.buffer = nil }
 // Appends items to end of buffer.
 func (l *list[T]) Append(items ...T) {
 	l.buffer = append(l.buffer, items...)
+}
+
+// Clone returns immutable clone of list.
+// Not copies capacity.
+func (l *list[T]) Clone() List[T] {
+	nl := new_list[T]()
+	nl.buffer = make([]T, l.Len())
+	_ = copy(nl.buffer, l.buffer)
+	return nl
 }
 
 func new_list[T any]() *list[T] {

--- a/list/list.go
+++ b/list/list.go
@@ -20,7 +20,7 @@ type List[T any] interface {
 	Clone() List[T]
 }
 
-// list[T] is an wrapper for the Go slices.
+// list[T] is a wrapper for the Go slices.
 type list[T any] struct { buff []T }
 
 // At equals to indexing on buffer slice.

--- a/list/list.go
+++ b/list/list.go
@@ -5,6 +5,7 @@ type List[T any] interface {
 	Len() int
 	Cap() int
 	Append(...T)
+	Empty() bool
 }
 
 // list[T] is an wrapper for the Go slices.
@@ -17,6 +18,9 @@ func (l *list[T]) Len() int { return len(l.buffer) }
 
 // Cap returns capacity of buffer.
 func (l *list[T]) Cap() int { return cap(l.buffer) }
+
+// Empty reports length is zero.
+func (l *list[T]) Empty() bool { return l.Len() == 0 }
 
 // Appends items to end of buffer.
 func (l *list[T]) Append(items ...T) {

--- a/list/list.go
+++ b/list/list.go
@@ -9,17 +9,15 @@ type List[T any] interface {
 	Len() int
 	Cap() int
 	Empty() bool
+	Append(...T)
 	String() string
 	Clear()
-	Append(...T)
 	Clone() List[T]
 	Map(func(T) T)
 }
 
 // list[T] is an wrapper for the Go slices.
-type list[T any] struct {
-	buff []T
-}
+type list[T any] struct { buff []T }
 
 // At equals to indexing on buffer slice.
 func (l *list[T]) At(i int) T { return l.buff[i] }
@@ -36,6 +34,9 @@ func (l *list[T]) Cap() int { return cap(l.buff) }
 // Empty reports length is zero.
 func (l *list[T]) Empty() bool { return l.Len() == 0 }
 
+// Appends items to end of buffer.
+func (l *list[T]) Append(items ...T) { l.buff = append(l.buff, items...) }
+
 func (l list[T]) String() string { return fmt.Sprint(l.buff) }
 
 // Clear removes all elements.
@@ -51,11 +52,6 @@ func (l *list[T]) Map(handler func(T) T) {
 		item := &l.buff[i]
 		*item = handler(*item)
 	}
-}
-
-// Appends items to end of buffer.
-func (l *list[T]) Append(items ...T) {
-	l.buff = append(l.buff, items...)
 }
 
 // Clone returns immutable clone of list.
@@ -76,15 +72,20 @@ func new_list[T any]() *list[T] {
 // New returns new list instance.
 func New[T any]() List[T] { return new_list[T]() }
 
-// NewBuff returns new list instance by capacity.
+// Make returns new list instance by length && capacity.
+// Equals to make([]T, len, cap)
 //
 // Special casees are;
-//   NewBuff[T](cap) = cap accepts as zero (0) if cap < 0
-func NewBuff[T any](cap int) List[T] {
+//   Make[T](len, cap) = len accepts as zero (0) if len < 0
+//   Make[T](len, cap) = cap accepts as zero (0) if cap < 0
+func Make[T any](len, cap int) List[T] {
 	l := new_list[T]()
+	if len < 0 {
+		len = 0
+	}
 	if cap < 0 {
 		cap = 0
 	}
-	l.buff = make([]T, 0, cap)
+	l.buff = make([]T, len, cap)
 	return l;
 }

--- a/list/list.go
+++ b/list/list.go
@@ -15,6 +15,7 @@ type List[T any] interface {
 	Buffer() []T
 	Insert(int, ...T)
 	RemoveAt(i int)
+	Foreach(func(T))
 	Map(func(T) T)
 	Clone() List[T]
 }
@@ -70,6 +71,17 @@ func (l *list[T]) RemoveAt(i int) {
 		panic("index is out of range")
 	}
 	l.buff = append(l.buff[:i], l.buff[i+1:]...)
+}
+
+// Foreach iterates on buffer.
+// Panics if handler == nil
+func (l *list[T]) Foreach(handler func(T)) {
+	if handler == nil {
+		panic("handler is nil")
+	}
+	for _, elem := range l.buff {
+		handler(elem)
+	}
 }
 
 // Map iterates on buffer and assign returned T to current offset.

--- a/list/list.go
+++ b/list/list.go
@@ -14,8 +14,9 @@ type List[T any] interface {
 	Clear()
 	Buffer() []T
 	Insert(int, ...T)
-	Clone() List[T]
+	RemoveAt(i int)
 	Map(func(T) T)
+	Clone() List[T]
 }
 
 // list[T] is an wrapper for the Go slices.
@@ -62,11 +63,20 @@ func (l *list[T]) Insert(i int, items ...T) {
 	l.buff = append(l.buff[:i], items...)
 }
 
+// RemoveAt removes element by offset.
+// Panics if i is out of range offset.
+func (l *list[T]) RemoveAt(i int) {
+	if l.Empty() || i < 0 || i >= l.Len() {
+		panic("index is out of range")
+	}
+	l.buff = append(l.buff[:i], l.buff[i+1:]...)
+}
+
 // Map iterates on buffer and assign returned T to current offset.
-// Does not nothing if handler == nil.
+// Panics if handler == nil.
 func (l *list[T]) Map(handler func(T) T) {
 	if handler == nil {
-		return
+		panic("handler is nil")
 	}
 	for i := range l.buff {
 		item := &l.buff[i]

--- a/list/list.go
+++ b/list/list.go
@@ -1,11 +1,14 @@
 package list
 
+import "fmt"
+
 // List[T] is an interface for safe statically typing.
 type List[T any] interface {
 	Len() int
 	Cap() int
 	Append(...T)
 	Empty() bool
+	String() string
 }
 
 // list[T] is an wrapper for the Go slices.
@@ -22,6 +25,8 @@ func (l *list[T]) Cap() int { return cap(l.buffer) }
 // Empty reports length is zero.
 func (l *list[T]) Empty() bool { return l.Len() == 0 }
 
+func (l list[T]) String() string { return fmt.Sprint(l.buffer) }
+
 // Appends items to end of buffer.
 func (l *list[T]) Append(items ...T) {
 	l.buffer = append(l.buffer, items...)
@@ -29,6 +34,7 @@ func (l *list[T]) Append(items ...T) {
 
 func new_list[T any]() *list[T] {
 	l := new(list[T])
+	l.buffer = nil
 	return l;
 }
 

--- a/list/list.go
+++ b/list/list.go
@@ -5,6 +5,7 @@ import "fmt"
 // List[T] is an interface for safe statically typing.
 type List[T any] interface {
 	At(int) T
+	Set(int, T)
 	Len() int
 	Cap() int
 	Empty() bool
@@ -21,6 +22,9 @@ type list[T any] struct {
 
 // At equals to indexing on buffer slice.
 func (l *list[T]) At(i int) T { return l.buffer[i] }
+
+// Set equals to indexed assignment on buffer slice.
+func (l *list[T]) Set(i int, item T) { l.buffer[i] = item }
 
 // Len returns length of elements.
 func (l *list[T]) Len() int { return len(l.buffer) }

--- a/list/list.go
+++ b/list/list.go
@@ -13,50 +13,63 @@ type List[T any] interface {
 	Clear()
 	Append(...T)
 	Clone() List[T]
+	Map(func(T) T)
 }
 
 // list[T] is an wrapper for the Go slices.
 type list[T any] struct {
-	buffer []T
+	buff []T
 }
 
 // At equals to indexing on buffer slice.
-func (l *list[T]) At(i int) T { return l.buffer[i] }
+func (l *list[T]) At(i int) T { return l.buff[i] }
 
 // Set equals to indexed assignment on buffer slice.
-func (l *list[T]) Set(i int, item T) { l.buffer[i] = item }
+func (l *list[T]) Set(i int, item T) { l.buff[i] = item }
 
 // Len returns length of elements.
-func (l *list[T]) Len() int { return len(l.buffer) }
+func (l *list[T]) Len() int { return len(l.buff) }
 
 // Cap returns capacity of buffer.
-func (l *list[T]) Cap() int { return cap(l.buffer) }
+func (l *list[T]) Cap() int { return cap(l.buff) }
 
 // Empty reports length is zero.
 func (l *list[T]) Empty() bool { return l.Len() == 0 }
 
-func (l list[T]) String() string { return fmt.Sprint(l.buffer) }
+func (l list[T]) String() string { return fmt.Sprint(l.buff) }
 
 // Clear removes all elements.
-func (l *list[T]) Clear() { l.buffer = nil }
+func (l *list[T]) Clear() { l.buff = nil }
+
+// Map iterates on buffer and assign returned T to current offset.
+// Does not nothing if handler == nil.
+func (l *list[T]) Map(handler func(T) T) {
+	if handler == nil {
+		return
+	}
+	for i := range l.buff {
+		item := &l.buff[i]
+		*item = handler(*item)
+	}
+}
 
 // Appends items to end of buffer.
 func (l *list[T]) Append(items ...T) {
-	l.buffer = append(l.buffer, items...)
+	l.buff = append(l.buff, items...)
 }
 
 // Clone returns immutable clone of list.
 // Not copies capacity.
 func (l *list[T]) Clone() List[T] {
 	nl := new_list[T]()
-	nl.buffer = make([]T, l.Len())
-	_ = copy(nl.buffer, l.buffer)
+	nl.buff = make([]T, l.Len())
+	_ = copy(nl.buff, l.buff)
 	return nl
 }
 
 func new_list[T any]() *list[T] {
 	l := new(list[T])
-	l.buffer = nil
+	l.buff = nil
 	return l;
 }
 
@@ -72,6 +85,6 @@ func NewBuff[T any](cap int) List[T] {
 	if cap < 0 {
 		cap = 0
 	}
-	l.buffer = make([]T, 0, cap)
+	l.buff = make([]T, 0, cap)
 	return l;
 }

--- a/list/list.go
+++ b/list/list.go
@@ -1,11 +1,13 @@
 package list
 
-// List is an interface for safe statically typing.
+// List[T] is an interface for safe statically typing.
 type List[T any] interface {
 	Len() int
 	Cap() int
+	Append(...T)
 }
 
+// list[T] is an wrapper for the Go slices.
 type list[T any] struct {
 	buffer []T
 }
@@ -15,6 +17,11 @@ func (l *list[T]) Len() int { return len(l.buffer) }
 
 // Cap returns capacity of buffer.
 func (l *list[T]) Cap() int { return cap(l.buffer) }
+
+// Appends items to end of buffer.
+func (l *list[T]) Append(items ...T) {
+	l.buffer = append(l.buffer, items...)
+}
 
 func new_list[T any]() *list[T] {
 	l := new(list[T])

--- a/list/list.go
+++ b/list/list.go
@@ -4,6 +4,7 @@ import "fmt"
 
 // List[T] is an interface for safe statically typing.
 type List[T any] interface {
+	At(int) T
 	Len() int
 	Cap() int
 	Empty() bool
@@ -17,6 +18,9 @@ type List[T any] interface {
 type list[T any] struct {
 	buffer []T
 }
+
+// At equals to indexing on buffer slice.
+func (l *list[T]) At(i int) T { return l.buffer[i] }
 
 // Len returns length of elements.
 func (l *list[T]) Len() int { return len(l.buffer) }

--- a/list/list.go
+++ b/list/list.go
@@ -6,9 +6,10 @@ import "fmt"
 type List[T any] interface {
 	Len() int
 	Cap() int
-	Append(...T)
 	Empty() bool
 	String() string
+	Clear()
+	Append(...T)
 }
 
 // list[T] is an wrapper for the Go slices.
@@ -26,6 +27,9 @@ func (l *list[T]) Cap() int { return cap(l.buffer) }
 func (l *list[T]) Empty() bool { return l.Len() == 0 }
 
 func (l list[T]) String() string { return fmt.Sprint(l.buffer) }
+
+// Clear removes all elements.
+func (l *list[T]) Clear() { l.buffer = nil }
 
 // Appends items to end of buffer.
 func (l *list[T]) Append(items ...T) {

--- a/list/list.go
+++ b/list/list.go
@@ -13,6 +13,7 @@ type List[T any] interface {
 	String() string
 	Clear()
 	Buffer() []T
+	Insert(int, ...T)
 	Clone() List[T]
 	Map(func(T) T)
 }
@@ -45,6 +46,21 @@ func (l *list[T]) Clear() { l.buff = nil }
 
 // Buffer returns buffer (mutable).
 func (l *list[T]) Buffer() []T { return l.buff }
+
+// Insert inserts items by offset.
+//
+// Special cases are;
+//   Insert(i, items) = appends if l.Empty() || i <= 0 || i >= l.Len()
+func (l *list[T]) Insert(i int, items ...T) {
+	// Special cases
+	if l.Empty() || i <= 0 || i >= l.Len() {
+		l.Append(items...)
+		return
+	}
+
+	items = append(items, l.buff[i:]...)
+	l.buff = append(l.buff[:i], items...)
+}
 
 // Map iterates on buffer and assign returned T to current offset.
 // Does not nothing if handler == nil.

--- a/list/list.go
+++ b/list/list.go
@@ -1,0 +1,38 @@
+package list
+
+// List is an interface for safe statically typing.
+type List[T any] interface {
+	Len() int
+	Cap() int
+}
+
+type list[T any] struct {
+	buffer []T
+}
+
+// Len returns length of elements.
+func (l *list[T]) Len() int { return len(l.buffer) }
+
+// Cap returns capacity of buffer.
+func (l *list[T]) Cap() int { return cap(l.buffer) }
+
+func new_list[T any]() *list[T] {
+	l := new(list[T])
+	return l;
+}
+
+// New returns new list instance.
+func New[T any]() List[T] { return new_list[T]() }
+
+// NewBuff returns new list instance by capacity.
+//
+// Special casees are;
+//   NewBuff[T](cap) = cap accepts as zero (0) if cap < 0
+func NewBuff[T any](cap int) List[T] {
+	l := new_list[T]()
+	if cap < 0 {
+		cap = 0
+	}
+	l.buffer = make([]T, 0, cap)
+	return l;
+}

--- a/list/list.go
+++ b/list/list.go
@@ -12,6 +12,7 @@ type List[T any] interface {
 	Append(...T)
 	String() string
 	Clear()
+	Buffer() []T
 	Clone() List[T]
 	Map(func(T) T)
 }
@@ -41,6 +42,9 @@ func (l list[T]) String() string { return fmt.Sprint(l.buff) }
 
 // Clear removes all elements.
 func (l *list[T]) Clear() { l.buff = nil }
+
+// Buffer returns buffer (mutable).
+func (l *list[T]) Buffer() []T { return l.buff }
 
 // Map iterates on buffer and assign returned T to current offset.
 // Does not nothing if handler == nil.

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -64,3 +64,13 @@ func TestString(t *testing.T) {
 		t.Errorf("Empty should return [10 20 30 40 50]")
 	}
 }
+
+func TestClear(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	l.Clear()
+
+	if l.Len() != 0 {
+		t.Errorf("Len should return zero")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -85,3 +85,14 @@ func TestClone(t *testing.T) {
 		t.Errorf("Clone returned false clone")
 	}
 }
+
+func TestAt(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	
+	n := l.At(0)
+
+	if n != 10 {
+		t.Errorf("n should be 10")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -36,3 +36,17 @@ func TestAppend(t *testing.T) {
 		t.Errorf("Len is should be 5")
 	}
 }
+
+func TestEmpty(t *testing.T) {
+	l := New[int]()
+
+	if !l.Empty() {
+		t.Errorf("Empty should return true")
+	}
+
+	l.Append(10, 20, 30, 40, 50)
+
+	if l.Empty() {
+		t.Errorf("Empty should return false")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -107,3 +107,16 @@ func TestSet(t *testing.T) {
 		t.Errorf("n should be 20")
 	}
 }
+
+func TestMap(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	
+	l.Map(func(item int) int {
+		return item * 10
+	})
+
+	if l.String() != "[100 200 300 400 500]" {
+		t.Errorf("String should return [100 200 300 400 500]")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -27,3 +27,12 @@ func TestCap(t *testing.T) {
 		t.Errorf("Cap is should be %d", CAP)
 	}
 }
+
+func TestAppend(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+
+	if l.Len() != 5 {
+		t.Errorf("Len is should be 5")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -9,7 +9,7 @@ func TestLen(t *testing.T) {
 	}
 
 	const CAP = 20
-	l2 := NewBuff[int](CAP)
+	l2 := Make[int](0, CAP)
 	if l2.Len() != 0 {
 		t.Errorf("Len is should be zero")
 	}
@@ -22,7 +22,7 @@ func TestCap(t *testing.T) {
 	}
 
 	const CAP = 20
-	l2 := NewBuff[int](CAP)
+	l2 := Make[int](0, CAP)
 	if l2.Cap() != CAP {
 		t.Errorf("Cap is should be %d", CAP)
 	}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -120,3 +120,14 @@ func TestMap(t *testing.T) {
 		t.Errorf("String should return [100 200 300 400 500]")
 	}
 }
+
+func TestBuffer(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	
+	buff := l.Buffer()
+
+	if len(buff) != l.Len() {
+		t.Errorf("Buffer returns false buffer data")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -131,3 +131,14 @@ func TestBuffer(t *testing.T) {
 		t.Errorf("Buffer returns false buffer data")
 	}
 }
+
+func TestInsert(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	l.Insert(2, 100, 200, 300)
+	t.Log(l.String())
+
+	if l.String() != "[10 20 100 200 300 30 40 50]" {
+		t.Errorf("String should return [10 20 100 200 300 30 40 50]")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -151,3 +151,22 @@ func TestRemoveAt(t *testing.T) {
 		t.Errorf("String should return [10 20 40 50]")
 	}
 }
+
+func TestForeach(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30)
+	offset := 0
+	l.Foreach(func(i int) {
+		switch {
+		case offset == 0 && i != 10:
+			t.Errorf("i is should be 10 when offset = 0")
+		case offset == 1 && i != 20:
+			t.Errorf("i is should be 20 when offset = 1")
+		case offset == 2 && i != 30:
+			t.Errorf("i is should be 30 when offset = 2")
+		case offset > 2:
+			t.Errorf("offset overflows length")
+		}
+		offset += 1
+	})
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -136,9 +136,18 @@ func TestInsert(t *testing.T) {
 	l := New[int]()
 	l.Append(10, 20, 30, 40, 50)
 	l.Insert(2, 100, 200, 300)
-	t.Log(l.String())
 
 	if l.String() != "[10 20 100 200 300 30 40 50]" {
 		t.Errorf("String should return [10 20 100 200 300 30 40 50]")
+	}
+}
+
+func TestRemoveAt(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	l.RemoveAt(2)
+
+	if l.String() != "[10 20 40 50]" {
+		t.Errorf("String should return [10 20 40 50]")
 	}
 }

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -74,3 +74,14 @@ func TestClear(t *testing.T) {
 		t.Errorf("Len should return zero")
 	}
 }
+
+func TestClone(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	
+	l2 := l.Clone()
+
+	if l.String() != l2.String() {
+		t.Errorf("Clone returned false clone")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -50,3 +50,17 @@ func TestEmpty(t *testing.T) {
 		t.Errorf("Empty should return false")
 	}
 }
+
+func TestString(t *testing.T) {
+	l := New[int]()
+
+	if l.String() != "[]" {
+		t.Errorf("String should return []")
+	}
+
+	l.Append(10, 20, 30, 40, 50)
+
+	if l.String() != "[10 20 30 40 50]" {
+		t.Errorf("Empty should return [10 20 30 40 50]")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -96,3 +96,14 @@ func TestAt(t *testing.T) {
 		t.Errorf("n should be 10")
 	}
 }
+
+func TestSet(t *testing.T) {
+	l := New[int]()
+	l.Append(10, 20, 30, 40, 50)
+	
+	l.Set(0, 20)
+
+	if l.At(0) != 20 {
+		t.Errorf("n should be 20")
+	}
+}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -1,0 +1,29 @@
+package list
+
+import "testing"
+
+func TestLen(t *testing.T) {
+	l := New[int]()
+	if l.Len() != 0 {
+		t.Errorf("Len is should be zero")
+	}
+
+	const CAP = 20
+	l2 := NewBuff[int](CAP)
+	if l2.Len() != 0 {
+		t.Errorf("Len is should be zero")
+	}
+}
+
+func TestCap(t *testing.T) {
+	l := New[int]()
+	if l.Cap() != 0 {
+		t.Errorf("Cap is should be zero")
+	}
+
+	const CAP = 20
+	l2 := NewBuff[int](CAP)
+	if l2.Cap() != CAP {
+		t.Errorf("Cap is should be %d", CAP)
+	}
+}


### PR DESCRIPTION
This PR adds the `list` package.
The `list` package includes wrapper for Go's slices.


This package implemented elementary, it uses Go's generics.
In the future, existing methods can be made more efficient, optimized, and new methods added for functionality.